### PR TITLE
feat: direct s3 uploads

### DIFF
--- a/packages/q3-api/lib/config/aws.js
+++ b/packages/q3-api/lib/config/aws.js
@@ -102,10 +102,11 @@ module.exports = () => {
     },
 
     async exists(Key) {
-      return s3.headObject({
-        Bucket: process.env.PRIVATE_BUCKET,
-        Key,
-      })
+      return s3
+        .headObject({
+          Bucket: process.env.PRIVATE_BUCKET,
+          Key,
+        })
         .promise()
         .then(() => true)
         .catch(() => false);

--- a/packages/q3-api/lib/config/aws.js
+++ b/packages/q3-api/lib/config/aws.js
@@ -50,6 +50,15 @@ module.exports = () => {
       });
     },
 
+    getSignedUrl(Key, ContentType) {
+      return s3.getSignedUrl('putObject', {
+        Bucket: PrivateBucket,
+        ContentType,
+        Key,
+        Expires: 86400, // one day
+      });
+    },
+
     addToBucket(p) {
       const meta = p
         ? {
@@ -90,6 +99,16 @@ module.exports = () => {
           },
         ),
       );
+    },
+
+    async exists(Key) {
+      return s3.headObject({
+        Bucket: process.env.PRIVATE_BUCKET,
+        Key,
+      })
+        .promise()
+        .then(() => true)
+        .catch(() => false);
     },
 
     /**

--- a/packages/q3-api/lib/models/files/adapter.js
+++ b/packages/q3-api/lib/models/files/adapter.js
@@ -1,4 +1,5 @@
 const { get } = require('lodash');
+const { exception } = require('q3-core-responder');
 const AWSInterface = require('../../config/aws');
 
 const normalize = (xs) =>
@@ -76,7 +77,7 @@ module.exports = class FileUploadAdapter {
         .msg('uploadFileToPrivateBucket')
         .throw();
     }
-    
+
     this.uploads.push({
       folderId,
       name,

--- a/packages/q3-api/lib/models/files/adapter.js
+++ b/packages/q3-api/lib/models/files/adapter.js
@@ -67,6 +67,27 @@ module.exports = class FileUploadAdapter {
     return this;
   }
 
+  async handleIndirectFile(filename, size) {
+    const sdk = AWSInterface();
+    const { folderId, name } = explodeName(filename);
+
+    if (!(await sdk.exists(`${this.id}/${name}`))) {
+      exception('BadRequest')
+        .msg('uploadFileToPrivateBucket')
+        .throw();
+    }
+    
+    this.uploads.push({
+      folderId,
+      name,
+      relativePath: name,
+      sensitive: true,
+      size,
+    });
+
+    await this.save();
+  }
+
   async handleFeaturedUpload({ files }) {
     const sdk = AWSInterface();
     const file = files[Object.keys(files)[0]];

--- a/packages/q3-api/lib/routes/s3-upload-transfer/post.js
+++ b/packages/q3-api/lib/routes/s3-upload-transfer/post.js
@@ -3,44 +3,38 @@ const path = require('path');
 const { exception } = require('q3-core-responder');
 const mongoose = require('../../config/mongoose');
 
-const S3UploadTransferPost = async (
-    req,
-    res,
-) => {
-    const {
-        collection,
-        id,
-        name,
-        size,
-    } = req.body;
+const S3UploadTransferPost = async (req, res) => {
+  const { collection, id, name, size } = req.body;
 
-    if (!path.extname(name)) {
-        exception('Validation')
-            .msg('missingFileExtension')
-            .field('name')
-            .throw();
-    }
+  if (!path.extname(name)) {
+    exception('Validation')
+      .msg('missingFileExtension')
+      .field('name')
+      .throw();
+  }
 
-    const model = mongoose.model(collection);
-    const doc = await model.findStrictly(id, {
-        select: '+uploads',
-    });
+  const model = mongoose.model(collection);
+  const doc = await model.findStrictly(id, {
+    select: '+uploads',
+  });
 
-    doc.checkAuthorizationForTotalSubDocument('uploads', 'Create');
-    await doc.handleIndirectFile(name, size);
+  doc.checkAuthorizationForTotalSubDocument(
+    'uploads',
+    'Create',
+  );
+  await doc.handleIndirectFile(name, size);
 
-    res.create({
-        message: 'newSubResourceAdded',
-        uploads: doc.uploads,
-    });
+  res.create({
+    message: 'newSubResourceAdded',
+    uploads: doc.uploads,
+  });
 };
 
 S3UploadTransferPost.validation = [
-    check('collection').isString(),
-    check('id').isString(),
-    check('name').isString(),
-    check('size').isNumeric(),
+  check('collection').isString(),
+  check('id').isString(),
+  check('name').isString(),
+  check('size').isNumeric(),
 ];
 
 module.exports = compose(S3UploadTransferPost);
-

--- a/packages/q3-api/lib/routes/s3-upload-transfer/post.js
+++ b/packages/q3-api/lib/routes/s3-upload-transfer/post.js
@@ -1,0 +1,46 @@
+const { compose, check } = require('q3-core-composer');
+const path = require('path');
+const { exception } = require('q3-core-responder');
+const mongoose = require('../../config/mongoose');
+
+const S3UploadTransferPost = async (
+    req,
+    res,
+) => {
+    const {
+        collection,
+        id,
+        name,
+        size,
+    } = req.body;
+
+    if (!path.extname(name)) {
+        exception('Validation')
+            .msg('missingFileExtension')
+            .field('name')
+            .throw();
+    }
+
+    const model = mongoose.model(collection);
+    const doc = await model.findStrictly(id, {
+        select: '+uploads',
+    });
+
+    doc.checkAuthorizationForTotalSubDocument('uploads', 'Create');
+    await doc.handleIndirectFile(name, size);
+
+    res.create({
+        message: 'newSubResourceAdded',
+        uploads: doc.uploads,
+    });
+};
+
+S3UploadTransferPost.validation = [
+    check('collection').isString(),
+    check('id').isString(),
+    check('name').isString(),
+    check('size').isNumeric(),
+];
+
+module.exports = compose(S3UploadTransferPost);
+

--- a/packages/q3-api/lib/routes/s3-upload/post.js
+++ b/packages/q3-api/lib/routes/s3-upload/post.js
@@ -1,0 +1,35 @@
+const { compose, check } = require('q3-core-composer');
+const aws = require('../../config/aws');
+const mongoose = require('../../config/mongoose');
+
+const S3UploadPost = async (
+    req,
+    res,
+) => {
+    const {
+        collection,
+        id,
+        mimetype,
+        name,
+    } = req.body;
+
+    (
+        // checks the doc exists
+        await mongoose.model(collection).findStrictly(id)
+        // checks the user can upload to this document eventually
+    ).checkAuthorizationForTotalSubDocument('uploads', 'Create');
+
+    res.create({
+        url: aws().getSignedUrl(`${id}/${name}`, mimetype),
+    });
+};
+
+S3UploadPost.validation = [
+    check('collection').isString(),
+    check('id').isString(),
+    check('name').isString(),
+    check('mimetype').isString(),
+];
+
+module.exports = compose(S3UploadPost);
+

--- a/packages/q3-api/lib/routes/s3-upload/post.js
+++ b/packages/q3-api/lib/routes/s3-upload/post.js
@@ -2,34 +2,27 @@ const { compose, check } = require('q3-core-composer');
 const aws = require('../../config/aws');
 const mongoose = require('../../config/mongoose');
 
-const S3UploadPost = async (
-    req,
-    res,
-) => {
-    const {
-        collection,
-        id,
-        mimetype,
-        name,
-    } = req.body;
+const S3UploadPost = async (req, res) => {
+  const { collection, id, mimetype, name } = req.body;
 
-    (
-        // checks the doc exists
-        await mongoose.model(collection).findStrictly(id)
-        // checks the user can upload to this document eventually
-    ).checkAuthorizationForTotalSubDocument('uploads', 'Create');
+  // checks the doc exists
+  (await mongoose.model(collection).findStrictly(id))
+    // checks the user can upload to this document eventually
+    .checkAuthorizationForTotalSubDocument(
+      'uploads',
+      'Create',
+    );
 
-    res.create({
-        url: aws().getSignedUrl(`${id}/${name}`, mimetype),
-    });
+  res.create({
+    url: aws().getSignedUrl(`${id}/${name}`, mimetype),
+  });
 };
 
 S3UploadPost.validation = [
-    check('collection').isString(),
-    check('id').isString(),
-    check('name').isString(),
-    check('mimetype').isString(),
+  check('collection').isString(),
+  check('id').isString(),
+  check('name').isString(),
+  check('mimetype').isString(),
 ];
 
 module.exports = compose(S3UploadPost);
-


### PR DESCRIPTION
For large files, using our `/uploads` endpoint is causing performance issues. To avoid infrastructure changes, I've opened two new endpoints for generating signed URLs and associating direct uploads back with our API. I've reused a lot of methods so that validation, folder behaviour, authorization, etc. remains the same.